### PR TITLE
Updated doc formatting

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,5 +1,5 @@
 MarkItUp! Bundle Documentation
-==========================
+==============================
 
 Reference Guide
 ---------------

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -4,7 +4,7 @@ Installation
 Base bundles
 ------------
 
-This bundle is mainely dependant of the SonataJqueryBundle. So be sure you have install this bundle before start:
+This bundle is mainly dependant of the SonataJqueryBundle. So be sure you have install this bundle before start:
 
  * http://sonata-project.org/bundles/jquery/master/doc/reference/installation.html
 
@@ -12,6 +12,8 @@ Installation
 ------------
 
 Retrieve the bundle with composer:
+
+.. code-block:: bash
 
     php composer.phar require sonata-project/markitup-bundle --no-update
 
@@ -31,5 +33,7 @@ Register the new bundle into your AppKernel:
   }
 
 Next, publish the assets:
+
+.. code-block:: bash
 
     php app/console assets:install web


### PR DESCRIPTION
@rande the link in the documentation is a dead link. Maybe we should add SonatajQueryBundle documentation to the sonata-project.org website?
